### PR TITLE
Feat type system

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TODO:
 ### Hello World
 ~~~~
 UwU?
-nuzzels "Hewwo World"
+nuzzels("Hewwo World")
 ~~~~
 
 ### finds the first Fibonacci number above 100
@@ -42,7 +42,7 @@ OwO *notices 100 gweatew twan b *
     a iws c
 stawp
 
-nuzzels b
+nuzzels(b)
 ~~~~
 
 ### print all prime numbers under 1000
@@ -68,14 +68,14 @@ i iws 2
 count iws 0
 OwO *notices i wess twan wimit*
     *notices siewe[i] eqwall twoo 0*
-        nuzzels i
+        nuzzels(i)
         count iws count pwus 1
     stawp
     i iws i pwus 1
 stawp
 
-nuzzels "Towtal numbwa of pwimes:"
-nuzzels count
+nuzzels("Towtal numbwa of pwimes:")
+nuzzels(count)
 ~~~~
 
 ### Print the nth Fibonacci number, now with recursion! 
@@ -93,7 +93,44 @@ nyaa *fiwb(a)*
     stawp
 wetuwn c
 
-nuzzels fiwb(20)
+nuzzels(fiwb(20))
+
+~~~~
+
+### UwU++ webserver
+
+~~~~
+UwU? iws twis a websewer?
+UwU Run this as "while true; do UwUpp-exe ./examples/webserver.uwu | nc -l 9090 -q 1; done"
+
+http iws "HTTP/1.0 200 UwU iws twis a websever???\r\n Server: UwU++\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n"
+
+
+UwU? is this dynawic contwent?
+nyaa *fiwb(a)*
+    *notices a gweatew twan 1*
+        c iws fiwb(a minwus 1) pwus fiwb(a minwus 2)
+    stawp
+    *notices a eqwall twoo  1*
+        c iws 1
+    stawp
+    *notices a eqwall twoo 0*
+        c iws 0
+    stawp
+wetuwn c
+
+dynawic iws fiwb(20)
+
+htmlStawt iws "<html>
+                <head></head>
+                <body>
+                    <h1>"
+
+htmlStawp iws " </h1>
+            </body>
+        </html>"
+
+nuzzels(http pwus htmlStawt pwus dynawic pwus htmlStawp)
 ~~~~
 
 ## Building the interpreter

--- a/examples/data.txt
+++ b/examples/data.txt
@@ -1,0 +1,4 @@
+Let there be light
+Let there be sky
+Let there be ground
+Let there be Life

--- a/examples/fibonacci.uwu
+++ b/examples/fibonacci.uwu
@@ -10,4 +10,4 @@ OwO *notices 1000 gweatew twan b *
     a iws c
 stawp
 
-nuzzels b
+nuzzels(b)

--- a/examples/hello.uwu
+++ b/examples/hello.uwu
@@ -1,2 +1,2 @@
 UwU whats this?
-nuzzels "Hello World"
+nuzzels("Hello World")

--- a/examples/io.uwu
+++ b/examples/io.uwu
@@ -1,0 +1,5 @@
+UwU? is this IO?
+
+nuzzels("What's your name?")
+name iws wead()
+nuzzels("*notices* " pwus name pwus " OwO")

--- a/examples/io.uwu
+++ b/examples/io.uwu
@@ -1,5 +1,5 @@
 UwU? is this IO?
 
 nuzzels("What's your name?")
-name iws wead()
+name iws wisten()
 nuzzels("*notices* " pwus name pwus " OwO")

--- a/examples/prime.uwu
+++ b/examples/prime.uwu
@@ -1,6 +1,6 @@
 UwU is twis the numbwe of pwimes undwe 10000?
 wimit iws 10000
-siewe iws awway<wimit>
+siewe iws awway<wimit;int>
 i iws 2
 OwO *notices i wess twan wimit diwide 10*
     *notices siewe[i] eqwall twoo 0*
@@ -17,14 +17,15 @@ stawp
 
 i iws 2
 count iws 0
+false iws 0
 OwO *notices i wess twan wimit*
     *notices siewe[i] eqwall twoo 0*
-        nuzzels i
+        nuzzels(i)
         count iws count pwus 1
     stawp
     i iws i pwus 1
 stawp
 
-nuzzels "Twotwal numbwa of pwimes"
-nuzzels count
+nuzzels("Twotwal numbwa of pwimes")
+nuzzels(count)
         

--- a/examples/rec.uwu
+++ b/examples/rec.uwu
@@ -1,4 +1,4 @@
-UwU? iws twis fibonacci?
+UwU? iws twis wecusiv fibonacci?
 nyaa *fiwb(a)*
     *notices a gweatew twan 1*
         c iws fiwb(a minwus 1) pwus fiwb(a minwus 2)
@@ -11,4 +11,4 @@ nyaa *fiwb(a)*
     stawp
 wetuwn c
 
-nuzzels fiwb(20)
+nuzzels(fiwb(20))

--- a/examples/text.uwu
+++ b/examples/text.uwu
@@ -1,0 +1,12 @@
+contwents iws wead("examples/data.txt")
+i iws 0
+
+OwO *notices i wess twan wength(contwents)*
+    words iws spwit(contwents[i], " ")
+    dumpState()
+    words[3] iws "UwU!"
+    contwents[i] iws conwat(words," ")
+    i iws i pwus 1
+stawp
+
+wite("new-data.txt",contwents)

--- a/examples/text.uwu
+++ b/examples/text.uwu
@@ -3,10 +3,9 @@ i iws 0
 
 OwO *notices i wess twan wength(contwents)*
     words iws spwit(contwents[i], " ")
-    dumpState()
     words[3] iws "UwU!"
     contwents[i] iws conwat(words," ")
     i iws i pwus 1
 stawp
 
-wite("new-data.txt",contwents)
+wite("examples/new-data.txt",contwents)

--- a/examples/webserver.uwu
+++ b/examples/webserver.uwu
@@ -1,0 +1,26 @@
+http iws "HTTP/1.0 200 UwU iws twis a websever???\r\n Server: UwU++\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n"
+
+nyaa *fiwb(a)*
+    *notices a gweatew twan 1*
+        c iws fiwb(a minwus 1) pwus fiwb(a minwus 2)
+    stawp
+    *notices a eqwall twoo  1*
+        c iws 1
+    stawp
+    *notices a eqwall twoo 0*
+        c iws 0
+    stawp
+wetuwn c
+
+dynawic iws fiwb(20)
+
+httpStawt iws "<html>
+                <head></head>
+                <body>
+                    <h1>"
+
+httpStawp iws " </h1>
+            </body>
+        </html>"
+
+nuzzels(http pwus httpStawt pwus dynawic pwus httpStawp)

--- a/examples/webserver.uwu
+++ b/examples/webserver.uwu
@@ -1,5 +1,10 @@
+UwU? iws twis a websewer?
+UwU Run this as "while true; do UwUpp-exe ./examples/webserver.uwu | nc -l 9090 -q 1; done"
+
 http iws "HTTP/1.0 200 UwU iws twis a websever???\r\n Server: UwU++\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n"
 
+
+UwU? is this dynawic contwent?
 nyaa *fiwb(a)*
     *notices a gweatew twan 1*
         c iws fiwb(a minwus 1) pwus fiwb(a minwus 2)
@@ -14,13 +19,13 @@ wetuwn c
 
 dynawic iws fiwb(20)
 
-httpStawt iws "<html>
+htmlStawt iws "<html>
                 <head></head>
                 <body>
                     <h1>"
 
-httpStawp iws " </h1>
+htmlStawp iws " </h1>
             </body>
         </html>"
 
-nuzzels(http pwus httpStawt pwus dynawic pwus httpStawp)
+nuzzels(http pwus htmlStawt pwus dynawic pwus htmlStawp)

--- a/new-data.txt
+++ b/new-data.txt
@@ -1,0 +1,4 @@
+Let there be UwU!
+Let there be UwU!
+Let there be UwU!
+Let there be UwU!

--- a/new-data.txt
+++ b/new-data.txt
@@ -1,4 +1,0 @@
-Let there be UwU!
-Let there be UwU!
-Let there be UwU!
-Let there be UwU!

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ dependencies:
 - containers >= 0.6.2 && < 1
 - mtl >= 2.2 && < 3.0
 - optparse-applicative >= 0.15 && < 1
+- split >= 0.2 && < 0.3
 
 library:
   source-dirs: src

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -4,6 +4,8 @@ type Name = String
 type Value = Int
 type Index = Int
 
+data ArrayType = ArrayTypeString | ArrayTypeInt deriving (Eq, Ord,Show)
+
 data Stmt
    = Assign Name Expr
    |  AssignIndex Expr Expr
@@ -12,7 +14,8 @@ data Stmt
    |  While Cond [Stmt]
    |  Print Expr
    |  PrintStr String
-   |  InitArray Name Expr
+   |  InitArray Name Expr ArrayType
+   |  FunctionCall Name [Expr]
    deriving (Eq, Ord, Show)
 
 data Cond
@@ -26,6 +29,7 @@ data Expr
   | Index Name Expr
   | Call Name [Expr]
   | Int Value
+  | Str String
   | Negation Expr
   | Sum      Expr Expr
   | Subtr    Expr Expr

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -48,5 +48,7 @@ run (Nothing,True)    = putStrLn "Failed to parse file, please double check spel
 run ((Just stmts),b)  = runExceptT (runProgram stmts) >>= reportResult b
 
 reportResult :: Bool -> Either RuntimeError () -> IO()
-reportResult _ (Right _ ) = return ()
-reportResult _ (Left e )  = print e
+reportResult _     (Right _ ) = return ()
+reportResult False   (Left e )  = print ("UwU? is dis a wuntwime ewwow?: " ++ uwuShow e)
+reportResult True (Left e )  = print ("The program failed to execute: "++ show e)
+

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -8,6 +8,7 @@ import Control.Monad.Except
 import Runtime
 import AST (Stmt)
 import Parser (pMain)
+import Type
 import Interpreter (runProgram)
 
 
@@ -45,3 +46,7 @@ run :: (Maybe [Stmt],Bool) -> IO()
 run (Nothing,False)   = putStrLn "OwO? fwile fwaild to parse"
 run (Nothing,True)    = putStrLn "Failed to parse file, please double check spelling"
 run ((Just stmts),b)  = runExceptT (runProgram stmts) >>= reportResult b
+
+reportResult :: Bool -> Either RuntimeError () -> IO()
+reportResult _ (Right _ ) = return ()
+reportResult _ (Left e )  = print e

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -108,7 +108,7 @@ evalExpr (Negation expr) st = do
     v <- evalExpr expr st
     case v of
         IntType i -> return $ IntType $ negate i
-        _ -> throwError $ NaNNegate
+        _ -> throwError $ CustomError "[Error] Can't negate a non number"
 
 evalExpr (Sum expr1 expr2) st = do 
     (e1,e2) <- evalBi expr1 expr2 st
@@ -117,27 +117,27 @@ evalExpr (Sum expr1 expr2) st = do
         (IntType i1, StrType s) -> return $ StrType $ (show i1) ++ s
         (StrType s, IntType i2) -> return $ StrType $ s ++ (show i2)
         (StrType s1, StrType s2) -> return $ StrType $ s1 ++ s2
-        _ -> throwError AddNotSupported
+        _ -> throwError $ CustomError "[Error] Add is only supported for ints and strings"
 
 evalExpr (Subtr expr1 expr2) st = do
     (e1,e2) <- evalBi expr1 expr2 st
     case (e1,e2) of
         (IntType i1, IntType i2) -> return $ IntType ( i1 - i2 )
-        _ -> throwError SubNotSupported
+        _ -> throwError $ CustomError "[Error] Subtraction is only supported for ints"
 
 evalExpr (Product expr1 expr2) st = do
     (e1,e2) <- evalBi expr1 expr2 st
     case (e1,e2) of
         (IntType i1, IntType i2) -> return $ IntType ( i1 * i2 )
-        _ -> throwError MulNotSupported
+        _ -> throwError $ CustomError "[Error] Multiplication is only supported for ints"
 
 evalExpr (Division expr1 expr2) st = do
     (e1,e2) <- evalBi expr1 expr2 st
     case (e1,e2) of
         (IntType i1, IntType i2) -> if i2 == 0
-                                then throwError DivideByZero
+                                then throwError $ CustomError "[Error] divide by 0 undefined"
                                 else return $ IntType $ i1 `div` i2
-        _ -> throwError DivNotSupported
+        _ -> throwError $ CustomError "[Error] Division is only supported for ints"
 
 
 evalCond' :: Ordering -> Expr -> Expr -> SymbolTable -> Runtime(Bool)

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -4,6 +4,7 @@ import Parser
 import AST
 import Runtime
 import Type
+import StdLib
 import qualified Data.Map as Map
 import Data.Ord
 import Data.Maybe

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -3,41 +3,36 @@ module Interpreter (runProgram) where
 import Parser
 import AST
 import Runtime
+import Type
 import qualified Data.Map as Map
+import Data.Ord
+import Data.Maybe
 import Control.Monad
 import Control.Monad.Except
 
-data Types = IntType Int | ArrayType [Int] | FType [String] [Stmt] Expr | PrintLog [String] deriving Show
-type SymbolTable = Map.Map String Types
-
 runProgram :: [Stmt] -> Runtime()
-runProgram stmts = foldM_ interpret Map.empty stmts
+runProgram stmts = foldM_ interpret initST stmts
 
-updateNth :: Int -> a -> [a] -> [a]
-updateNth _ _ [] = error "Error in interpreter: updateNth reached []. please contact developer"
-updateNth n v (x:xs)
-    | n == 0    = v : xs
-    | otherwise = x : updateNth (n-1) v xs
-
-updateList :: Index -> Value -> Name -> [Value] -> Runtime [Value]
-updateList _ _ _ []    = error "Error in interpreter: updateList reached []. please contact developer"
-updateList i v n xs
-    | length xs <= i = throwError $ IndexOutOfBounds i n
-    | i < 0          = throwError $ NegativeIndex i n
-    | otherwise      = return $ updateNth i v xs
+nativeWrapper :: [Name] -> [Stmt] -> Expr -> [Type] -> SymbolTable -> Runtime(Type)
+nativeWrapper arg_names body ret args st = runFunction >>= evalExpr ret 
+    where   
+        runFunction = do
+            let argPairs = zip arg_names args
+            let fstmt = foldl (\m (n,v) -> Map.insert n v m) st argPairs 
+            foldM interpret fstmt body
 
 interpret :: SymbolTable -> Stmt -> Runtime(SymbolTable)
-interpret st (Assign n expr) = evalExpr expr st >>= (\val -> return $ Map.insert n (IntType val) st)
+interpret st (Assign n expr) = evalExpr expr st >>= (\val -> return $ Map.insert n val st)
 interpret st (AssignIndex (Index name index) expr) =
     do
         i <- (evalExpr index st)
         v <- (evalExpr expr st)
         case Map.lookup name st of
-            Just (ArrayType xs) -> updateList i v name xs >>= (\newArr -> return $ Map.insert name (ArrayType newArr) st)
-            _                   -> throwError $ VariableNotAnArray name
+            Just arr -> put arr i v >>= (\v' -> return $ Map.insert name v' st)
+            _ -> throwError $ UndeclaredVariable name
 
 interpret st (Function name args stmts ret) =
-    return $ Map.insert name (FType args stmts ret) st
+    return $ Map.insert name (FType (nativeWrapper args stmts ret)) st
 
 interpret st (If cond stmts) = do
     c <- evalCond cond st
@@ -51,68 +46,106 @@ interpret st (While cond stmts) = do
         then foldM interpret st stmts >>= (\nst -> interpret nst (While cond stmts))
         else return $ st
 
-interpret st (Print expr) = evalExpr expr st >>= liftIO.print >> return st
+interpret st (Print expr) = evalExpr expr st >>= liftIO.print.fromJust.typeShow >> return st
 
 interpret st (PrintStr str) = liftIO (print str) >> return st
 
-interpret st (InitArray n expr) = do
-    len <- evalExpr expr st
-    if len <= 0
-        then throwError $ NonPositivArraySize len n
-        else return $ Map.insert n (ArrayType (replicate len 0)) st
+interpret st (InitArray n expr ArrayTypeString) = do
+    v <- evalExpr expr st
+    case v of
+        (IntType len) -> if len <= 0
+                        then throwError $ NonPositivArraySize len n
+                        else return $ Map.insert n (StrArrayType (replicate len (StrType ""))) st
+        _ -> throwError NonIntIndex
 
-evalBiOp :: (Value -> Value -> Value) -> Expr -> Expr -> SymbolTable -> Runtime(Value)
-evalBiOp f expr1 expr2 st = do
+interpret st (InitArray n expr ArrayTypeInt) = do
+    v <- evalExpr expr st
+    case v of
+        (IntType len) -> if len <= 0
+                        then throwError $ NonPositivArraySize len n
+                        else return $ Map.insert n (IntArrayType (replicate len (IntType 0))) st
+        _ -> throwError NonIntIndex
+
+interpret st (FunctionCall n exprs) = do
+    case Map.lookup n st of
+        Just (FType f) -> do
+            eval_args <- mapM (\e -> evalExpr e st) exprs
+            f eval_args st
+            return st
+        _ -> throwError $ UndeclaredFunction n
+
+evalBi :: Expr -> Expr -> SymbolTable -> Runtime((Type,Type))
+evalBi expr1 expr2 st = do
     e1 <- evalExpr expr1 st
     e2 <- evalExpr expr2 st
-    return $ (f) e1 e2
+    return (e1,e2)
 
-evalExpr :: Expr -> SymbolTable -> Runtime(Value)
+evalExpr :: Expr -> SymbolTable -> Runtime(Type)
 evalExpr (Var name) st =
     case Map.lookup name st of
-        Just (IntType val) -> return val
+        Just v -> return v
         _ -> throwError $ UndeclaredVariable name
                 
 evalExpr (Index name expr) st = do
     val <- evalExpr expr st
     case Map.lookup name st of
-        Just (ArrayType xs) -> if length xs > val
-                                    then return $ xs !! val
-                                    else throwError $ IndexOutOfBounds val name
-        _ -> throwError $ VariableNotAnArray name
+        Just arr -> get arr val
+        Nothing -> throwError $ UndeclaredVariable name
 
 evalExpr (Call name args) st =
     case Map.lookup name st of
-        Just (FType arg_names stmts ret) -> runFunction >>= evalExpr ret 
-            where
-                runFunction = do
-                    eval_args <- mapM (\e -> evalExpr e st) args
-                    let named_args = zip arg_names eval_args
-                    fstmt <- foldM interpret st $ [Assign n (Int v) | (n,v) <- named_args]
-                    foldM interpret fstmt stmts
+        Just (FType f) -> do
+            eval_args <- mapM (\e -> evalExpr e st) args
+            f eval_args st
         _ -> throwError $ UndeclaredFunction name
         
 
 
-evalExpr (Int v) _ = return v
-evalExpr (Negation expr) st = evalExpr expr st >>= (return.negate)
-evalExpr (Sum expr1 expr2) st = evalBiOp (+) expr1 expr2 st  
-evalExpr (Subtr expr1 expr2) st = evalBiOp (-) expr1 expr2 st  
-evalExpr (Product expr1 expr2) st = evalBiOp (*) expr1 expr2 st  
-evalExpr (Division expr1 expr2) st = do
-    e1 <- evalExpr expr1 st
-    e2 <- evalExpr expr2 st
-    if e2 == 0
-        then throwError DivideByZero
-        else return $ e1 `div` e2
+evalExpr (Int v) _ = return $ IntType v
+evalExpr (Str v) _ = return $ StrType v
+evalExpr (Negation expr) st = do 
+    v <- evalExpr expr st
+    case v of
+        IntType i -> return $ IntType $ negate i
+        _ -> throwError $ NaNNegate
 
-evalCond' :: (Value -> Value -> Bool) -> Expr -> Expr -> SymbolTable -> Runtime(Bool)
-evalCond' f e1 e2 st = do
-    v1 <- evalExpr e1 st
-    v2 <- evalExpr e2 st
-    return $ (f) v1 v2
+evalExpr (Sum expr1 expr2) st = do 
+    (e1,e2) <- evalBi expr1 expr2 st
+    case (e1,e2) of
+        (IntType i1, IntType i2) -> return $ IntType ( i1 + i2 )
+        (IntType i1, StrType s) -> return $ StrType $ (show i1) ++ s
+        (StrType s, IntType i2) -> return $ StrType $ s ++ (show i2)
+        (StrType s1, StrType s2) -> return $ StrType $ s1 ++ s2
+        _ -> throwError AddNotSupported
+
+evalExpr (Subtr expr1 expr2) st = do
+    (e1,e2) <- evalBi expr1 expr2 st
+    case (e1,e2) of
+        (IntType i1, IntType i2) -> return $ IntType ( i1 - i2 )
+        _ -> throwError SubNotSupported
+
+evalExpr (Product expr1 expr2) st = do
+    (e1,e2) <- evalBi expr1 expr2 st
+    case (e1,e2) of
+        (IntType i1, IntType i2) -> return $ IntType ( i1 * i2 )
+        _ -> throwError MulNotSupported
+
+evalExpr (Division expr1 expr2) st = do
+    (e1,e2) <- evalBi expr1 expr2 st
+    case (e1,e2) of
+        (IntType i1, IntType i2) -> if i2 == 0
+                                then throwError DivideByZero
+                                else return $ IntType $ i1 `div` i2
+        _ -> throwError DivNotSupported
+
+
+evalCond' :: Ordering -> Expr -> Expr -> SymbolTable -> Runtime(Bool)
+evalCond' o expr1 expr2 st = do
+    (e1,e2) <- evalBi expr1 expr2 st
+    ord <- cmpType e1 e2
+    return $ ord == o
 
 evalCond :: Cond -> SymbolTable -> Runtime(Bool)
-evalCond (Great e1 e2) st = evalCond' (>) e1 e2 st
-evalCond (Less e1 e2) st =  evalCond' (<) e1 e2 st
-evalCond (Equal e1 e2) st = evalCond' (==) e1 e2 st
+evalCond (Great e1 e2) st = evalCond' GT e1 e2 st
+evalCond (Less e1 e2) st =  evalCond' LT e1 e2 st
+evalCond (Equal e1 e2) st = evalCond' EQ e1 e2 st

--- a/src/Runtime.hs
+++ b/src/Runtime.hs
@@ -5,34 +5,50 @@ import AST
 
 data RuntimeError = UndeclaredVariable Name
     | UndeclaredFunction Name
-    | VariableNotAnArray Name
+    | VariableNotAnArray
     | NonPositivArraySize Index Name
     | NegativeIndex Index Name
-    | IndexOutOfBounds Index Name
+    | IndexOutOfBounds Index
+    | NonIntIndex
+    | PrintFunction
+    | NoArguments
+    | TooManyArgs
+    | CastToIntFail String
+    | NaNNegate
+    | AddNotSupported
+    | SubNotSupported
+    | MulNotSupported
+    | DivNotSupported
+    | CmpNotSupported
     | DivideByZero
-
+    | NaNError
+    deriving Show
+{-
 instance Show RuntimeError where
     show (UndeclaredVariable s)     = "[Error] There was an attempt to use an undeclared variable " ++ s
     show (UndeclaredFunction s)     = "[Error] There was an attempt to call an undeclared function " ++ s
-    show (VariableNotAnArray s)     = "[Error] There was an attempt to use variable " ++ s ++ "as an array, when it was not defined as such"
+    show (VariableNotAnArray)     = "[Error] There was an attempt to index an non-array variable"
     show (NonPositivArraySize i s)  = "[Error] There was an attempt to create an array " ++ s ++ " with size " ++ (show i) ++ ". All array sizes must be larger than 0"
+    show (NonIntIndex)             = "[Error] There was an attempt to index an array with non-integer values"
     show (NegativeIndex i s)        = "[Error] Negative indexes are currently not supported: " ++ s ++ "[" ++ (show i) ++ "]."
-    show (IndexOutOfBounds i s)     = "[Error] Index " ++ (show i) ++ " is out of bounds for array " ++ s
+    show (IndexOutOfBounds i )     = "[Error] Index " ++ (show i) ++ " is out of bounds"
     show (DivideByZero)             = "[Error] Divide by zero is undefined"
 
 uwuShow :: RuntimeError -> String
 uwuShow (UndeclaredVariable s)     = "[Ewwow] Thewe was an attwempt tuwu use an undecwawed vawiabwe " ++ s
 uwuShow (UndeclaredFunction s)     = "[Ewwow] Thewe was an attwempt tuwu caww an undecwawed functiown " ++ s
-uwuShow (VariableNotAnArray s)     = "[Ewwow] Thewe was an attwempt tuwu use vawiabwe " ++ s ++ "as an awway, whewn iwt was nowt defined as such"
+uwuShow (VariableNotAnArray)     = "[Ewwow] Thewe was an attwempt tuwu use a vawiabwe as an awway, whewn iwt was nowt defined as such"
 uwuShow (NonPositivArraySize i s)  = "[Ewwow] Thewe was an attempt tuwu cweate an awway " ++ s ++ " wif sise " ++ (show i) ++ ". Aww awway sizes must bwe wawgew than 0"
 uwuShow (NegativeIndex i s)        = "[Ewwow] Negatwive indexwes awe cuwwentwy nowt suppowted UwU: " ++ s ++ "[" ++ (show i) ++ "]."
-uwuShow (IndexOutOfBounds i s)     = "[Ewwow] Indwex " ++ (show i) ++ " iws out of bounds fow awway " ++ s
+uwuShow (IndexOutOfBounds i)     = "[Ewwow] Indwex " ++ (show i) ++ " iws out of bounds fow awway"
 uwuShow (DivideByZero)             = "[Ewwow] Divide by zewo iws undefined"
-
+-}
 
 type Runtime = ExceptT RuntimeError IO
 
+{-
 reportResult :: Bool -> Either RuntimeError () -> IO()
 reportResult _     (Right _ ) = return ()
 reportResult False   (Left e )  = print ("UwU? is dis a wuntwime ewwow?: " ++ uwuShow e)
-reportResult True (Left e )  = print ("The program failed to execute: "++ show e)  
+reportResult True (Left e )  = print ("The program failed to execute: "++ show e)
+-}

--- a/src/Runtime.hs
+++ b/src/Runtime.hs
@@ -21,6 +21,8 @@ data RuntimeError = UndeclaredVariable Name
     | DivNotSupported
     | CmpNotSupported
     | DivideByZero
+    | CustomError String
+    | InvalidArguments
     | NaNError
     deriving Show
 {-

--- a/src/Runtime.hs
+++ b/src/Runtime.hs
@@ -14,18 +14,10 @@ data RuntimeError = UndeclaredVariable Name
     | NoArguments
     | TooManyArgs
     | CastToIntFail String
-    | NaNNegate
-    | AddNotSupported
-    | SubNotSupported
-    | MulNotSupported
-    | DivNotSupported
-    | CmpNotSupported
-    | DivideByZero
     | CustomError String
     | InvalidArguments
     | NaNError
-    deriving Show
-{-
+
 instance Show RuntimeError where
     show (UndeclaredVariable s)     = "[Error] There was an attempt to use an undeclared variable " ++ s
     show (UndeclaredFunction s)     = "[Error] There was an attempt to call an undeclared function " ++ s
@@ -34,8 +26,8 @@ instance Show RuntimeError where
     show (NonIntIndex)             = "[Error] There was an attempt to index an array with non-integer values"
     show (NegativeIndex i s)        = "[Error] Negative indexes are currently not supported: " ++ s ++ "[" ++ (show i) ++ "]."
     show (IndexOutOfBounds i )     = "[Error] Index " ++ (show i) ++ " is out of bounds"
-    show (DivideByZero)             = "[Error] Divide by zero is undefined"
-
+    show (CustomError e)          = e
+    
 uwuShow :: RuntimeError -> String
 uwuShow (UndeclaredVariable s)     = "[Ewwow] Thewe was an attwempt tuwu use an undecwawed vawiabwe " ++ s
 uwuShow (UndeclaredFunction s)     = "[Ewwow] Thewe was an attwempt tuwu caww an undecwawed functiown " ++ s
@@ -43,8 +35,8 @@ uwuShow (VariableNotAnArray)     = "[Ewwow] Thewe was an attwempt tuwu use a vaw
 uwuShow (NonPositivArraySize i s)  = "[Ewwow] Thewe was an attempt tuwu cweate an awway " ++ s ++ " wif sise " ++ (show i) ++ ". Aww awway sizes must bwe wawgew than 0"
 uwuShow (NegativeIndex i s)        = "[Ewwow] Negatwive indexwes awe cuwwentwy nowt suppowted UwU: " ++ s ++ "[" ++ (show i) ++ "]."
 uwuShow (IndexOutOfBounds i)     = "[Ewwow] Indwex " ++ (show i) ++ " iws out of bounds fow awway"
-uwuShow (DivideByZero)             = "[Ewwow] Divide by zewo iws undefined"
--}
+uwuShow (CustomError e)         = e
+
 
 type Runtime = ExceptT RuntimeError IO
 

--- a/src/StdLib.hs
+++ b/src/StdLib.hs
@@ -1,0 +1,103 @@
+module StdLib(initST) where
+
+import Type 
+import Control.Monad.Except (liftIO,throwError)
+import Runtime
+import qualified Data.Map as Map
+import Data.Maybe
+import Data.List
+import Data.List.Split (splitOn)
+
+initST :: SymbolTable
+initST = Map.fromList init
+    where init = [ ("dumpState", FType dump_st)
+                , ("nuzzels",FType std_print)
+                , ("wisten",FType std_read)
+                , ("wistenInt",FType std_readInt)
+                , ("wead", FType std_readFile)
+                , ("wite", FType std_writeFile)
+                , ("conwat", FType std_concat)
+                , ("spwit", FType std_split)
+                , ("wength", FType std_length)]
+
+-- debug
+
+dump_st :: Function
+dump_st _ st = liftIO (print st) >> return (IntType 0)
+
+-- Array
+
+std_length :: Function
+std_length [] _ = throwError NoArguments
+std_length ((IntArrayType xs) : []) _ = return $ IntType $ length xs
+std_length ((StrArrayType xs) : []) _ = return $ IntType $ length xs
+std_length _ _ = throwError $ CustomError "Cant get length of a non array type" 
+
+
+-- IO
+
+std_print :: Function
+std_print [] _ = throwError NoArguments
+std_print a _ = do
+    liftIO $ putStrLn $ unwords $ mapMaybe typeShow a
+    return $ IntType 0
+
+std_read :: Function
+std_read [] _ = do
+    s <- liftIO getLine
+    return $ StrType s
+
+std_readInt :: Function
+std_readInt [] _ = do
+    i <- liftIO readLn :: Runtime Int
+    return $ IntType i
+
+std_readFile :: Function
+std_readFile [] _ = throwError $ NoArguments
+std_readFile ((StrType f) : []) _ = do
+    c <- liftIO (readFile f) :: Runtime String
+    let l = lines c
+    return $ StrArrayType $ map StrType l
+std_readFile _ _ = throwError $ InvalidArguments
+
+std_writeFile :: Function
+std_writeFile [] _ = throwError $ NoArguments
+std_writeFile ((StrType p) : (StrType s) : []) _ = do
+    liftIO $ writeFile p s
+    return $ IntType 0
+
+std_writeFile (p : (StrArrayType ss) : []) st = 
+    std_writeFile [p,StrType (unlines $ map extract ss)] st
+    where
+        extract :: Type -> String
+        extract (StrType s) = s
+        extract _ = error "Invalid usage of extract"
+
+
+
+std_writeFile _ _ = throwError $ InvalidArguments
+
+-- String
+-- Concat StrArrayType to StrType
+std_concat :: Function
+std_concat [] _ = throwError $ NoArguments
+std_concat ((StrArrayType xs) : []) _ = return $ StrType $ concat $ map extract xs
+    where
+        extract :: Type -> String
+        extract (StrType s) = s
+        extract _ = error "Invalid usage of extract"
+
+std_concat ((StrArrayType xs) : (StrType sep) : []) _ = return $ StrType $ concat $ intersperse sep $ map extract xs
+    where
+        extract :: Type -> String
+        extract (StrType s) = s
+        extract _ = error "Invalid usage of extract"
+std_concat _ _ = throwError $ InvalidArguments
+
+-- Split StrType to StrArrayType
+std_split :: Function
+std_split [] _ = throwError $ NoArguments
+std_split ((StrType s) : (StrType splt) : []) _
+    | length splt >= length s = throwError $ CustomError "Splitting element longer than string"
+    | splt == ""            = return $ StrArrayType [StrType s]
+    | otherwise = return $ StrArrayType $ map StrType $ splitOn splt s

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -3,6 +3,7 @@ module Type where
 import Runtime
 import Data.Maybe
 import Data.Ord
+import Data.List
 import qualified Data.Map as Map
 import Control.Monad.Except
 import Text.Read
@@ -22,8 +23,8 @@ data Type = IntType I32
 instance Show Type where
     show (IntType i) = show i
     show (StrType s) = s
-    show (StrArrayType ss) = unwords $ map show ss
-    show (IntArrayType is) = unwords $ map show is
+    show (StrArrayType ss) = unwords $ intersperse "," $ map show ss
+    show (IntArrayType is) = unwords $ intersperse "," $ map show is
     show (FType _) = "Function"
 
 cmpType :: Type -> Type -> Runtime(Ordering)
@@ -88,25 +89,3 @@ typeShow (StrArrayType vs) = Just $ unwords $ mapMaybe typeShow vs
 typeShow (FType _ )      = Nothing
  
 type SymbolTable = Map.Map String Type
-
-initST :: SymbolTable
-initST = Map.fromList init
-    where init = [ ("nuzzels",FType std_print)
-                , ("wead",FType std_read)
-                , ("weadInt",FType std_readInt)]
-
-std_print :: Function
-std_print [] _ = throwError NoArguments
-std_print a _ = do
-    liftIO $ putStrLn $ unwords $ mapMaybe typeShow a
-    return $ IntType 0
-
-std_read :: Function
-std_read [] _ = do
-    s <- liftIO getLine
-    return $ StrType s
-
-std_readInt :: Function
-std_readInt [] _ = do
-    i <- liftIO readLn :: Runtime Int
-    return $ IntType i

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -1,0 +1,112 @@
+module Type where
+
+import Runtime
+import Data.Maybe
+import Data.Ord
+import qualified Data.Map as Map
+import Control.Monad.Except
+import Text.Read
+import AST (Stmt,Expr)
+
+type I32 = Int
+type Str = String
+
+type Function = ([Type] -> SymbolTable -> Runtime(Type)) 
+
+data Type = IntType I32 
+    | IntArrayType [Type]
+    | StrType String
+    | StrArrayType [Type]
+    | FType Function
+
+instance Show Type where
+    show (IntType i) = show i
+    show (StrType s) = s
+    show (StrArrayType ss) = unwords $ map show ss
+    show (IntArrayType is) = unwords $ map show is
+    show (FType _) = "Function"
+
+cmpType :: Type -> Type -> Runtime(Ordering)
+cmpType (IntType a) (IntType b) = return $ compare a b
+cmpType (StrType a) (StrType b) = return $ compare a b
+cmpType _ _ = throwError CmpNotSupported
+
+
+safeIndex :: [a] -> Int -> Maybe a
+safeIndex [] _ = Nothing
+safeIndex (x:xs) 0 = Just x
+safeIndex (x:xs) i = safeIndex xs (i-1)
+
+safeUpdate :: [a] -> a -> Int -> Maybe [a]
+safeUpdate [] _ _ = Nothing
+safeUpdate (a:as) v 0 = Just (v : as)
+safeUpdate (a:as) v i = safeUpdate as v (i-1) >>= (\xs -> return $ a:xs)
+
+
+get :: Type -> Type -> Runtime(Type)
+get (IntArrayType xs) (IntType i) = 
+    case safeIndex xs i of
+        Just (IntType x) -> return (IntType x)
+        Nothing -> throwError $ IndexOutOfBounds i
+
+get (StrArrayType xs) (IntType i) =
+    case safeIndex xs i of
+        Just (StrType x) -> return (StrType x)
+        Nothing -> throwError $ IndexOutOfBounds i
+
+get _ (IntType _ ) = throwError VariableNotAnArray
+get _ _          = throwError NonIntIndex
+
+put :: Type -> Type -> Type -> Runtime(Type)
+put (IntArrayType xs) (IntType i) (IntType v) =
+    case safeUpdate xs (IntType v) i of
+        Just xs' -> return $ IntArrayType xs'
+        Nothing -> throwError $ IndexOutOfBounds i
+
+put (IntArrayType xs) (IntType i) (StrType v) =
+    case readMaybe v :: Maybe Int of
+        Just i -> put (IntArrayType xs) (IntType i) (IntType i)
+        Nothing -> throwError $ CastToIntFail v
+    
+put (StrArrayType xs) (IntType i) (StrType v) =
+    case safeUpdate xs (StrType v) i of
+        Just xs' -> return $ StrArrayType xs'
+        Nothing -> throwError $ IndexOutOfBounds i
+
+put (StrArrayType xs) (IntType i) (IntType v) =
+    put (StrArrayType xs) (IntType i) (StrType (show v))
+
+
+put _ (IntType _ ) _ = throwError VariableNotAnArray
+put _ _ _ = throwError NonIntIndex
+
+typeShow :: Type -> Maybe String
+typeShow (IntType v)      = Just $ show v
+typeShow (IntArrayType vs) = Just $ unwords $ mapMaybe typeShow vs
+typeShow (StrType v)      = Just v
+typeShow (StrArrayType vs) = Just $ unwords $ mapMaybe typeShow vs
+typeShow (FType _ )      = Nothing
+ 
+type SymbolTable = Map.Map String Type
+
+initST :: SymbolTable
+initST = Map.fromList init
+    where init = [ ("nuzzels",FType std_print)
+                , ("wead",FType std_read)
+                , ("weadInt",FType std_readInt)]
+
+std_print :: Function
+std_print [] _ = throwError NoArguments
+std_print a _ = do
+    liftIO $ putStrLn $ unwords $ mapMaybe typeShow a
+    return $ IntType 0
+
+std_read :: Function
+std_read [] _ = do
+    s <- liftIO getLine
+    return $ StrType s
+
+std_readInt :: Function
+std_readInt [] _ = do
+    i <- liftIO readLn :: Runtime Int
+    return $ IntType i

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -30,7 +30,7 @@ instance Show Type where
 cmpType :: Type -> Type -> Runtime(Ordering)
 cmpType (IntType a) (IntType b) = return $ compare a b
 cmpType (StrType a) (StrType b) = return $ compare a b
-cmpType _ _ = throwError CmpNotSupported
+cmpType _ _ = throwError $ CustomError "[Error] Compare is not supported for arrays or mixed types"
 
 
 safeIndex :: [a] -> Int -> Maybe a


### PR DESCRIPTION
In order to add IO functions, i had to implement an simple type system. The type system is like js, where types are inferred on runtime. While this will lead to unexpected runtime errors, I believe that it follows the spirit of uwu++

This pr also adds some IO functions making use out of the new type systems, some of which are documented in the example text.uwu

Like from python 2.7 to python 3, nuzzels expr has changed to nuzzels(expr) to better conform to the rest of the specification

Support for calling a function without assigning the resulting value is now added, since now functions can have side affects.